### PR TITLE
fix(docs): redundant phrasing in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sudo make install
 
 You can refer to `example/cmake_sample` on how to import the unitree_sdk2 into your CMake project. 
 
-Note that if you install the library to other places other than `/opt/unitree_robotics`, you need to make sure the path is added to "${CMAKE_PREFIX_PATH}" so that cmake can find it with "find_package()".
+Note that if you install the library to places other than `/opt/unitree_robotics`, you need to make sure the path is added to "${CMAKE_PREFIX_PATH}" so that cmake can find it with "find_package()".
 
 ### Notice
 For more reference information, please go to [Unitree Document Center](https://support.unitree.com/home/zh/developer).


### PR DESCRIPTION
Updated the phrase "other places other than" to "places other than" in the installation section of the documentation. The original phrasing contained unnecessary repetition, which could lead to minor confusion or reduce readability.