### PR TITLE
Add package.xml to build unitree_sdk2 in the catkin/colcon workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 Unitree robot sdk version 2.
 
 ### Prebuild environment
-* OS  (Ubuntu 20.04 LTS)  
-* CPU  (aarch64 and x86_64)   
-* Compiler  (gcc version 9.4.0) 
+* OS  (Ubuntu 20.04 LTS)
+* CPU  (aarch64 and x86_64)
+* Compiler  (gcc version 9.4.0)
 
 ### Environment Setup
 
@@ -21,6 +21,12 @@ apt-get update
 apt-get install -y cmake g++ build-essential libyaml-cpp-dev libeigen3-dev libboost-all-dev libspdlog-dev libfmt-dev
 ```
 
+or if you have the catkin/colcon workspace:
+```bash
+apt-get update && rosdep update
+rosdep install -iqry --from-paths unitree_sdk2
+```
+
 ### Build examples
 
 To build the examples inside this repository:
@@ -30,6 +36,13 @@ mkdir build
 cd build
 cmake ..
 make
+```
+
+or if you have the catkin/colcon workspace:
+
+```bash
+catkin bt # for catkin
+colcon build --packages-select unitree_sdk2 # for colcon. Execute it under the toplevel of the colcon workspace
 ```
 
 ### Installation
@@ -52,7 +65,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX=/opt/unitree_robotics
 sudo make install
 ```
 
-You can refer to `example/cmake_sample` on how to import the unitree_sdk2 into your CMake project. 
+You can refer to `example/cmake_sample` on how to import the unitree_sdk2 into your CMake project.
 
 Note that if you install the library to other places other than `/opt/unitree_robotics`, you need to make sure the path is added to "${CMAKE_PREFIX_PATH}" so that cmake can find it with "find_package()".
 

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>unitree_sdk2</name>
+  <version>2.0.0</version>
+  <description>Unitree SDK2: DDS-based communication library for Unitree robots (pre-built)</description>
+  <maintainer email="support@unitree.com">Unitree Robotics</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <depend>yaml-cpp</depend>
+  <depend>eigen</depend>
+  <depend>boost</depend>
+  <depend>spdlog</depend>
+  <depend>fmt</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This PR supports building unitree_sdk2 under the colcon/catkin workspace with adding package.xml .

- **Add package.xml to build unitree_sdk2 in colcon/catkin workspace**
- **update README.md to build unitree_sdk2 under the catkin/colcon workspace**
